### PR TITLE
Don't block on sending on channel for Timer either

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -273,7 +273,10 @@ func (t *internalTimer) Tick(now time.Time) {
 	if t.fn != nil {
 		t.fn()
 	} else {
-		t.c <- now
+		select {
+		case t.c <- now:
+		default:
+		}
 	}
 	t.mock.removeClockTimer((*internalTimer)(t))
 	gosched()


### PR DESCRIPTION
This wasn't a problem upstream because Reset() doesn't exist there.
