### PR TITLE
Correct unit tests and races

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: go
 go: 
  - 1.3
  - 1.4
- - release
  - tip
 sudo: false

--- a/clock.go
+++ b/clock.go
@@ -87,7 +87,7 @@ func (m *Mock) Add(d time.Duration) {
 	gosched()
 }
 
-// Sets the current time of the mock clock to a specific one.
+// Set sets the current time of the mock clock to a specific one.
 // This should only be called from a single goroutine at a time.
 func (m *Mock) Set(t time.Time) {
 	// Continue to execute timers until there are no more before the new time.

--- a/clock_test.go
+++ b/clock_test.go
@@ -3,52 +3,71 @@ package clock
 import (
 	"fmt"
 	"os"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
+type Bool struct {
+	uint32
+}
+
+func (o *Bool) Set() {
+	atomic.StoreUint32(&o.uint32, 1)
+}
+func (o *Bool) IsSet() bool {
+	return atomic.LoadUint32(&o.uint32) == 1
+}
+
 // Ensure that the clock's After channel sends at the correct time.
 func TestClock_After(t *testing.T) {
-	var ok bool
+	tooLate := make(chan struct{})
+	ok := new(Bool)
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		ok = true
+		ok.Set()
 	}()
 	go func() {
 		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
+		close(tooLate)
 	}()
 	gosched()
 
-	<-New().After(20 * time.Millisecond)
-	if !ok {
-		t.Fatal("too early")
+	select {
+	case <-New().After(20 * time.Millisecond):
+		if !ok.IsSet() {
+			t.Fatal("too early")
+		}
+	case <-tooLate:
+		t.Fatal("too late")
 	}
 }
 
 // Ensure that the clock's AfterFunc executes at the correct time.
 func TestClock_AfterFunc(t *testing.T) {
-	var ok bool
+	finished := make(chan struct{})
+	tooLate := make(chan struct{})
+	ok := new(Bool)
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		ok = true
+		ok.Set()
 	}()
 	go func() {
 		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
+		close(tooLate)
 	}()
 	gosched()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
 	New().AfterFunc(20*time.Millisecond, func() {
-		wg.Done()
+		close(finished)
 	})
-	wg.Wait()
-	if !ok {
-		t.Fatal("too early")
+	select {
+	case <-finished:
+		if !ok.IsSet() {
+			t.Fatal("too early")
+		}
+	case <-tooLate:
+		t.Fatal("too late")
 	}
 }
 
@@ -63,62 +82,90 @@ func TestClock_Now(t *testing.T) {
 
 // Ensure that the clock sleeps for the appropriate amount of time.
 func TestClock_Sleep(t *testing.T) {
-	var ok bool
+	tooLate := make(chan struct{})
+	ok := new(Bool)
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		ok = true
+		ok.Set()
 	}()
 	go func() {
 		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
+		close(tooLate)
 	}()
 	gosched()
 
 	New().Sleep(20 * time.Millisecond)
-	if !ok {
-		t.Fatal("too early")
+	select {
+	case <-tooLate:
+		t.Fatal("too late")
+	default:
+		if !ok.IsSet() {
+			t.Fatal("too early")
+		}
 	}
 }
 
 // Ensure that the clock ticks correctly.
 func TestClock_Tick(t *testing.T) {
-	var ok bool
+	tooLate := make(chan struct{})
+	ok := new(Bool)
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		ok = true
+		ok.Set()
 	}()
 	go func() {
 		time.Sleep(50 * time.Millisecond)
-		t.Fatal("too late")
+		close(tooLate)
 	}()
 	gosched()
 
 	c := New().Tick(20 * time.Millisecond)
-	<-c
-	<-c
-	if !ok {
-		t.Fatal("too early")
+	var seen bool
+	for {
+		select {
+		case <-c:
+			if !seen {
+				seen = true
+				continue
+			}
+			if !ok.IsSet() {
+				t.Fatal("too early")
+			}
+			return
+		case <-tooLate:
+			t.Fatal("too late")
+		}
 	}
 }
 
 // Ensure that the clock's ticker ticks correctly.
 func TestClock_Ticker(t *testing.T) {
-	var ok bool
+	tooLate := make(chan struct{})
+	var ok int32
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		ok = true
+		atomic.StoreInt32(&ok, 1)
 	}()
 	go func() {
 		time.Sleep(200 * time.Millisecond)
-		t.Fatal("too late")
 	}()
 	gosched()
 
 	ticker := New().Ticker(50 * time.Millisecond)
-	<-ticker.C
-	<-ticker.C
-	if !ok {
-		t.Fatal("too early")
+	var seen bool
+	for {
+		select {
+		case <-ticker.C:
+			if seen {
+				if ok := atomic.LoadInt32(&ok); ok == 0 {
+					t.Fatal("too early")
+				}
+				return
+			}
+			seen = true
+		case <-tooLate:
+			t.Fatal("too late")
+		}
 	}
 }
 
@@ -143,21 +190,26 @@ func TestClock_Ticker_Stp(t *testing.T) {
 
 // Ensure that the clock's timer waits correctly.
 func TestClock_Timer(t *testing.T) {
-	var ok bool
+	tooLate := make(chan struct{})
+	ok := new(Bool)
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		ok = true
+		ok.Set()
 	}()
 	go func() {
 		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
+		close(tooLate)
 	}()
 	gosched()
 
 	timer := New().Timer(20 * time.Millisecond)
-	<-timer.C
-	if !ok {
-		t.Fatal("too early")
+	select {
+	case <-timer.C:
+		if !ok.IsSet() {
+			t.Fatal("too early")
+		}
+	case <-tooLate:
+		t.Fatal("too late")
 	}
 }
 
@@ -420,10 +472,15 @@ func TestMock_Ticker_Multi(t *testing.T) {
 	}
 }
 
+type Count struct{ int32 }
+
+func (c *Count) Set(d int32) { atomic.StoreInt32(&c.int32, d) }
+func (c *Count) Load() int32 { return atomic.LoadInt32(&c.int32) }
+
 func ExampleMock_After() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	count := new(Count)
 
 	ready := make(chan struct{})
 	// Create a channel to execute after 10 mock seconds.
@@ -431,20 +488,20 @@ func ExampleMock_After() {
 		ch := clock.After(10 * time.Second)
 		close(ready)
 		<-ch
-		count = 100
+		count.Set(100)
 	}()
 	<-ready
 
 	// Print the starting value.
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.Load())
 
 	// Move the clock forward 5 seconds and print the value again.
 	clock.Add(5 * time.Second)
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.Load())
 
 	// Move the clock forward 5 seconds to the tick time and check the value.
 	clock.Add(5 * time.Second)
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.Load())
 
 	// Output:
 	// 1970-01-01 00:00:00 +0000 UTC: 0
@@ -455,20 +512,20 @@ func ExampleMock_After() {
 func ExampleMock_AfterFunc() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	count := new(Count)
 
 	// Execute a function after 10 mock seconds.
 	clock.AfterFunc(10*time.Second, func() {
-		count = 100
+		count.Set(100)
 	})
 	gosched()
 
 	// Print the starting value.
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.Load())
 
 	// Move the clock forward 10 seconds and print the new value.
 	clock.Add(10 * time.Second)
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.Load())
 
 	// Output:
 	// 1970-01-01 00:00:00 +0000 UTC: 0
@@ -478,21 +535,21 @@ func ExampleMock_AfterFunc() {
 func ExampleMock_Sleep() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	count := new(Count)
 
 	// Execute a function after 10 mock seconds.
 	go func() {
 		clock.Sleep(10 * time.Second)
-		count = 100
+		count.Set(100)
 	}()
 	gosched()
 
 	// Print the starting value.
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.Load())
 
 	// Move the clock forward 10 seconds and print the new value.
 	clock.Add(10 * time.Second)
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.Load())
 
 	// Output:
 	// 1970-01-01 00:00:00 +0000 UTC: 0
@@ -502,7 +559,7 @@ func ExampleMock_Sleep() {
 func ExampleMock_Ticker() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	count := new(Count)
 
 	ready := make(chan struct{})
 	// Increment count every mock second.
@@ -511,18 +568,18 @@ func ExampleMock_Ticker() {
 		close(ready)
 		for {
 			<-ticker.C
-			count++
+			count.Set(count.Load() + 1)
 		}
 	}()
 	<-ready
 
 	// Move the clock forward 10 seconds and print the new value.
 	clock.Add(10 * time.Second)
-	fmt.Printf("Count is %d after 10 seconds\n", count)
+	fmt.Printf("Count is %d after 10 seconds\n", count.Load())
 
 	// Move the clock forward 5 more seconds and print the new value.
 	clock.Add(5 * time.Second)
-	fmt.Printf("Count is %d after 15 seconds\n", count)
+	fmt.Printf("Count is %d after 15 seconds\n", count.Load())
 
 	// Output:
 	// Count is 10 after 10 seconds
@@ -532,7 +589,7 @@ func ExampleMock_Ticker() {
 func ExampleMock_Timer() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	count := new(Count)
 
 	ready := make(chan struct{})
 	// Increment count after a mock second.
@@ -540,13 +597,14 @@ func ExampleMock_Timer() {
 		timer := clock.Timer(1 * time.Second)
 		close(ready)
 		<-timer.C
-		count++
+		count.Set(count.Load() + 1)
+
 	}()
 	<-ready
 
 	// Move the clock forward 10 seconds and print the new value.
 	clock.Add(10 * time.Second)
-	fmt.Printf("Count is %d after 10 seconds\n", count)
+	fmt.Printf("Count is %d after 10 seconds\n", count.Load())
 
 	// Output:
 	// Count is 1 after 10 seconds


### PR DESCRIPTION
- the "too late" go routine did not finish before the end of the function.
      correct this invalid usage by signalling "too late" using a channel close.
- the read and writes of the 'ok' boolean failed race detection.
      avoid ordering issues by using `sync/atomic`.
- the counters in the examples also suffered from ordering issues. use
      an atomic for stronger ordering.

This package now passes `go test -race`.